### PR TITLE
Added ID input to input element with default ID of "FileBase64"

### DIFF
--- a/src/js/components/react-file-base64.js
+++ b/src/js/components/react-file-base64.js
@@ -66,11 +66,13 @@ export default class FileBase64 extends React.Component {
       <input
         type="file"
         onChange={ this.handleChange.bind(this) }
-        multiple={ this.props.multiple } />
+        multiple={ this.props.multiple }
+        id={ this.props.id } />
     );
   }
 }
 
 FileBase64.defaultProps = {
   multiple: false,
+  id: "FileBase64",
 };


### PR DESCRIPTION
Allow FileBase64 to accept ID props, where it can be used to manipulate and customise the `Choose File` button. Ideally, the input element can be set as `display: none`, and a label can be used instead by using the `htmlFor` attribute and that can be styled instead.